### PR TITLE
Fix typo in Icon Lib example values

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ A `RefParser` resolves `$ref` references in JSON Schemas by dereferencing then.
         Specifies the icon library to use for UI components. Valid options include:
         <ul>
           <li><code>'glyphicons'</code></li>
-          <li><code>'bootstrapIcons'</code></li>
+          <li><code>'bootstrap-icons'</code></li>
           <li><code>'fontawesome3'</code></li>
           <li><code>'fontawesome4'</code></li>
           <li><code>'fontawesome5'</code></li>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ A `RefParser` resolves `$ref` references in JSON Schemas by dereferencing then.
   }
 }
 ```
-
+ 
 ## Instance Options
 
 <table>
@@ -177,10 +177,10 @@ A `RefParser` resolves `$ref` references in JSON Schemas by dereferencing then.
         <ul>
           <li><code>'glyphicons'</code></li>
           <li><code>'bootstrapIcons'</code></li>
-          <li><code>'fontAwesome3'</code></li>
-          <li><code>'fontAwesome4'</code></li>
-          <li><code>'fontAwesome5'</code></li>
-          <li><code>'fontAwesome6'</code></li>
+          <li><code>'fontawesome3'</code></li>
+          <li><code>'fontawesome4'</code></li>
+          <li><code>'fontawesome5'</code></li>
+          <li><code>'fontawesome6'</code></li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
Names must be written in lower case in this case. e.g. in Playground it is also written in lower case and it also only works in that way.

Ref in code: https://github.com/germanbisurgi/jedi/blob/034e3740689c94856cbd8828f69886f2ae40d7f9/src/jedi.js#L144-L161