### PR TITLE
changed $ref from absolute URL to relative URL

### DIFF
--- a/src/ref-parser/ref-parser.js
+++ b/src/ref-parser/ref-parser.js
@@ -88,7 +88,7 @@ class RefParser {
       return false
     }
 
-    return ref.startsWith('http') || ref.startsWith('https')
+    return ref[0] !== '#'
   }
 
   isObject (value) {


### PR DESCRIPTION
I noticed the $ref, when URL, only allows full URL with "http".  This change will allow for partial and full paths as well.

Hopefully I've understood JSON Schema correctly, but local ref should always start with hash (#), so this change will attempt to load $ref as URL if it's not hash.
