### PR TITLE
feat: add x-buttons keyword for schema-defined action buttons

### DIFF
--- a/src-docs/App.vue
+++ b/src-docs/App.vue
@@ -378,6 +378,7 @@ import switcherSelectInline from './json/features/switcher-select-inline.json'
 import navigateTo from './json/features/navigate-to.json'
 import titleIconClass from './json/features/title-icon-class.json'
 import switcherTypeLabels from './json/features/switcher-type-labels.json'
+import xButtons from './json/features/x-buttons.json'
 import experimentalObjectNoCard from './json/experimental/object-no-card.json'
 import experimentalObjectHorizontal from './json/experimental/object-horizontal.json'
 import {isSet} from "../src/helpers/utils.js"
@@ -489,6 +490,7 @@ export default {
           'features/navigate-to': navigateTo,
           'features/title-icon-class': titleIconClass,
           'features/switcher-type-labels': switcherTypeLabels,
+          'features/x-buttons': xButtons,
           'parsing/json-patch': jsonPatch,
           'parsing/allOf-refs': allOfRefs,
           'parsing/allOf-if-then': allOfIfThen,
@@ -1854,6 +1856,19 @@ export default {
       window.editor = this.editor
       this.editorChangeHandler()
       this.editor.on('change', this.editorChangeHandler)
+
+      // x-buttons feature demo (playground only): react to the events the
+      // features/x-buttons schema emits. Harmless for other schemas.
+      const events = ['detectCity', 'insertTemplate', 'clearComment', 'zipLookup']
+      events.forEach((name) => {
+        this.editor.on('jedison:' + name, ({ editor, path }) => {
+          console.log('jedison:' + name, { path })
+          if (name === 'detectCity') editor.instance.setValue('Stuttgart')
+          if (name === 'insertTemplate') editor.instance.setValue('Dear customer, thank you for your message.')
+          if (name === 'clearComment') editor.instance.setValue('')
+          if (name === 'zipLookup') editor.instance.setValue({ ...editor.instance.getValue(), city: 'Stuttgart' })
+        })
+      })
     },
     editorChangeHandler() {
       const errors = this.editor.getErrors()

--- a/src-docs/json/features/x-buttons.json
+++ b/src-docs/json/features/x-buttons.json
@@ -1,0 +1,67 @@
+{
+  "type": "object",
+  "title": "x-buttons",
+  "description": "The `x-buttons` keyword adds schema-defined action buttons to any editor without becoming part of the data model. Each button emits a `jedison:<name>` event on the instance; subscribe with `instance.on('jedison:<name>', ({ jedison, editor, path }) => { ... })`. Open the browser console to see emitted events.",
+  "properties": {
+    "city": {
+      "type": "string",
+      "title": "City",
+      "description": "String editor with a single button. The label is sanitized HTML, so it can carry an icon.",
+      "x-buttons": [
+        {
+          "label": "<i class=\"fas fa-location-dot\"></i> Detect city",
+          "event": {
+            "name": "detectCity"
+          },
+          "attributes": {
+            "class": "my-custom-button",
+            "data-analytics": "detect-city"
+          }
+        }
+      ]
+    },
+    "comment": {
+      "type": "string",
+      "x-format": "textarea",
+      "title": "Comment",
+      "description": "Multiple buttons on one editor.",
+      "x-buttons": [
+        {
+          "label": "Insert template",
+          "event": {
+            "name": "insertTemplate"
+          }
+        },
+        {
+          "label": "Clear",
+          "event": {
+            "name": "clearComment"
+          }
+        }
+      ]
+    },
+    "address": {
+      "type": "object",
+      "title": "Address",
+      "description": "Buttons also work on container editors. A lookup button that fills several child fields.",
+      "properties": {
+        "zip": {
+          "type": "string",
+          "title": "ZIP"
+        },
+        "city": {
+          "type": "string",
+          "title": "City"
+        }
+      },
+      "x-buttons": [
+        {
+          "label": "Lookup by ZIP",
+          "event": {
+            "name": "zipLookup"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src-docs/json/meta-schema.json
+++ b/src-docs/json/meta-schema.json
@@ -337,6 +337,33 @@
         "x-discriminator": {
           "x-propGroup": "Options",
           "type": "string"
+        },
+        "x-buttons": {
+          "x-propGroup": "Options",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "event": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name"]
+              },
+              "attributes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/editors/editor.js
+++ b/src/editors/editor.js
@@ -1,4 +1,4 @@
-import { combineDeep, compileTemplate, isObject, isSet, pathToAttribute } from '../helpers/utils.js'
+import { combineDeep, compileTemplate, filterAttributes, isArray, isObject, isSet, isString, pathToAttribute } from '../helpers/utils.js'
 import { getSchemaDescription, getSchemaTitle, getSchemaType, getSchemaXOption } from '../helpers/schema.js'
 
 /**
@@ -58,6 +58,7 @@ class Editor {
     this.addEventListeners()
     this.setVisibility()
     this.setContainerAttributes()
+    this.appendSchemaButtons()
     this.refreshUI()
 
     const alwaysShowErrors = this.instance.jedison.getOption('showErrors') === 'always' || getSchemaXOption(this.instance.schema, 'showErrors') === 'always'
@@ -123,6 +124,97 @@ class Editor {
         }
       }
     }
+  }
+
+  /**
+   * Renders schema-defined action buttons (the `x-buttons` keyword) into the
+   * editor container. Works for every editor because it lives on the base
+   * class, next to setAttributes()/setContainerAttributes(). Both `x-buttons`
+   * and `x-options.buttons` spellings resolve through getSchemaXOption().
+   *
+   * Security decisions from issue #62:
+   * - The label is HTML sanitized through the existing DOMPurify pipeline
+   *   (purifyContent(), decision 9c / F6) before being handed to the theme.
+   * - The `attributes` bag is filtered against an allowlist (filterAttributes(),
+   *   decision 6a / F1); `always-enabled` / `always-disabled` are intentionally
+   *   allowed (decision 6b, trusted-schema stance).
+   * - Each button emits a `jedison:<name>` event on the root Jedison instance
+   *   through the internal EventEmitter (decision 1c / 2), carrying a live
+   *   payload `{ jedison, editor, path }` (decision 8). Consumers subscribe with
+   *   `jedison.on('jedison:<name>', ({ jedison, editor, path }) => ...)`. The
+   *   listener map is private to the instance, so the payload is not exposed to
+   *   unrelated scripts on the page (F3 contained).
+   * - Click listeners are registered through storedEventListeners so destroy()
+   *   cleans them up.
+   */
+  appendSchemaButtons () {
+    const buttons = getSchemaXOption(this.instance.schema, 'buttons')
+
+    if (!isArray(buttons)) {
+      return
+    }
+
+    const debug = this.instance.jedison.getOption('debug')
+    const domPurifyOptions = this.instance.jedison.getOption('domPurifyOptions')
+
+    buttons.forEach((config) => {
+      if (!isObject(config)) {
+        if (debug) {
+          console.warn('Jedison: x-buttons entry is not an object and was skipped.', config)
+        }
+        return
+      }
+
+      // Label: HTML sanitized through the existing DOMPurify pipeline (decision 9c / F6).
+      const rawLabel = isString(config.label) ? config.label : ''
+      const label = this.purifyEnabled ? this.purifyContent(rawLabel, domPurifyOptions) : rawLabel
+
+      // Attributes: allowlist-filtered (decision 6a / F1). __proto__ etc. never pass the allowlist (F5).
+      const attributes = filterAttributes(config.attributes, {
+        onDrop: (key) => {
+          if (debug) {
+            console.warn(`Jedison: x-buttons attribute "${key}" is not allowlisted and was dropped.`)
+          }
+        }
+      })
+
+      const button = this.theme.getXButton({ label, attributes })
+
+      this.control.container.appendChild(button)
+
+      const eventName = (isObject(config.event) && isString(config.event.name)) ? config.event.name : null
+
+      if (!eventName) {
+        if (debug) {
+          console.warn('Jedison: x-buttons entry has no event.name; button renders but dispatches nothing.', config)
+        }
+        return
+      }
+
+      const handler = () => {
+        const jedison = this.instance.jedison
+
+        if (!jedison) {
+          return
+        }
+
+        // Emit on the root Jedison instance (decision 1c, root only). The
+        // payload is a single context object passed positionally.
+        jedison.emit('jedison:' + eventName, {
+          jedison,
+          editor: this,
+          path: this.instance.path
+        })
+      }
+
+      button.addEventListener('click', handler)
+
+      this.storedEventListeners.push({
+        element: button,
+        eventType: 'click',
+        handler
+      })
+    })
   }
 
   /**

--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -21,8 +21,32 @@ class EventEmitter {
     callbacks.push(callback)
   }
 
-  off (name) {
-    this.listeners.delete(name)
+  /**
+   * Removes event listeners for a named event.
+   * @public
+   * @param {string} name - The name of the event
+   * @param {function} [callback] - When given, only this specific callback is
+   * removed; when omitted, all listeners for the event are removed.
+   */
+  off (name, callback) {
+    if (typeof callback !== 'function') {
+      this.listeners.delete(name)
+      return
+    }
+
+    const callbacks = this.listeners.get(name)
+
+    if (!callbacks) {
+      return
+    }
+
+    const remaining = callbacks.filter((cb) => cb !== callback)
+
+    if (remaining.length === 0) {
+      this.listeners.delete(name)
+    } else {
+      this.listeners.set(name, remaining)
+    }
   }
 
   /**

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -247,6 +247,71 @@ export function getType (value) {
 }
 
 /**
+ * Default allowlist of exact attribute names accepted from a schema-supplied
+ * attribute bag (e.g. x-buttons `attributes`). Everything else is dropped.
+ * @type {string[]}
+ */
+export const DEFAULT_ATTRIBUTE_ALLOWLIST = [
+  'id',
+  'class',
+  'title',
+  'name',
+  'value',
+  'disabled',
+  'always-enabled',
+  'always-disabled'
+]
+
+/**
+ * Attribute name prefixes accepted in addition to the exact allowlist.
+ * @type {string[]}
+ */
+export const DEFAULT_ATTRIBUTE_ALLOWED_PREFIXES = ['aria-', 'data-']
+
+/**
+ * Filters a schema-supplied attribute bag against an allowlist. Only keys that
+ * either match the exact allowlist (case-insensitive) or start with one of the
+ * allowed prefixes are kept; everything else (event handlers like `on*`,
+ * `style`, `formaction`, unsafe keys like `__proto__`, ...) is dropped. This is
+ * the shared helper referenced by the x-buttons security decisions and is meant
+ * to be retrofitted onto x-inputAttributes / x-containerAttributes later.
+ * @param {object} attributes - The raw attribute bag from the schema
+ * @param {object} [options] - Options
+ * @param {string[]} [options.allowlist] - Exact attribute names to keep
+ * @param {string[]} [options.allowedPrefixes] - Name prefixes to keep
+ * @param {function} [options.onDrop] - Called with each dropped attribute name
+ * @return {object} A new object containing only the allowed attributes
+ */
+export function filterAttributes (attributes, options = {}) {
+  const {
+    allowlist = DEFAULT_ATTRIBUTE_ALLOWLIST,
+    allowedPrefixes = DEFAULT_ATTRIBUTE_ALLOWED_PREFIXES,
+    onDrop
+  } = options
+
+  const result = {}
+
+  if (!isObject(attributes)) {
+    return result
+  }
+
+  const allowed = new Set(allowlist.map((name) => name.toLowerCase()))
+
+  for (const [key, value] of Object.entries(attributes)) {
+    const normalizedKey = key.trim().toLowerCase()
+    const isAllowed = allowed.has(normalizedKey) || allowedPrefixes.some((prefix) => normalizedKey.startsWith(prefix))
+
+    if (isAllowed) {
+      result[key] = value
+    } else if (typeof onDrop === 'function') {
+      onDrop(key)
+    }
+  }
+
+  return result
+}
+
+/**
  * Merges objects
  * @param {object} target - The target object
  * @param {object[]} sources - Objects to be merged into the target object

--- a/src/themes/theme.js
+++ b/src/themes/theme.js
@@ -647,6 +647,49 @@ class Theme {
     return button
   }
 
+  /**
+   * A schema-defined action button (x-buttons keyword).
+   *
+   * This method only renders: the label is expected to be already sanitized by
+   * the editor (Editor.purifyContent(), decision 9c) and the attributes are
+   * expected to be already filtered against the allowlist by the editor
+   * (utils.filterAttributes(), decision 6a). The theme does not sanitize or
+   * filter. No theme styling is applied, only the unstyled `jedi-x-button` hook
+   * class (decision 4).
+   * @param {object} config - Button config
+   * @param {string} [config.label] - Pre-sanitized HTML label
+   * @param {object} [config.attributes] - Pre-filtered HTML attributes
+   * @return {HTMLButtonElement}
+   */
+  getXButton (config = {}) {
+    const button = document.createElement('button')
+    const label = document.createElement('span')
+
+    button.classList.add('jedi-x-button')
+    button.setAttribute('type', 'button')
+
+    label.classList.add('jedi-x-button-label')
+    // config.label is pre-sanitized HTML (decision 9c); safe to assign as innerHTML.
+    label.innerHTML = config.label ?? ''
+    button.appendChild(label)
+
+    const attributes = isObject(config.attributes) ? config.attributes : {}
+
+    for (const [key, value] of Object.entries(attributes)) {
+      if (key === 'class') {
+        String(value).split(' ').forEach((cls) => {
+          if (cls) {
+            button.classList.add(cls)
+          }
+        })
+      } else {
+        button.setAttribute(key, value)
+      }
+    }
+
+    return button
+  }
+
   getAddPropertyButton (config) {
     const html = this.getButton(config)
     html.classList.add('jedi-add-property-btn')

--- a/tests/e2e/tests/features/x-buttons_test.cjs
+++ b/tests/e2e/tests/features/x-buttons_test.cjs
@@ -1,0 +1,161 @@
+/* global Feature Scenario BeforeSuite */
+const theme = process.env.THEME || 'barebones'
+const pathToSchema = 'features/x-buttons'
+
+// Adversarial schema used by the security scenario. Kept as a raw JSON string
+// (not a JS object) so that `__proto__` survives as an own property through
+// JSON.parse in the playground's setSchema(), exactly like an untrusted schema
+// arriving over the wire (F5). Exercises F1 (attribute allowlist) and
+// F6 (label sanitization) as well.
+const maliciousSchema = JSON.stringify({
+  type: 'object',
+  properties: {
+    field: {
+      type: 'string',
+      title: 'Field',
+      'x-buttons': [
+        {
+          label: '<img src=x onerror="window.__xssRan = true"> <i class="fas fa-check"></i> Go',
+          event: { name: 'secTest' },
+          attributes: {
+            id: 'sec-btn',
+            'data-ok': 'yes',
+            onclick: 'window.__onclickRan = true',
+            style: 'position:fixed;top:0;left:0',
+            formaction: 'https://evil.example'
+          }
+        }
+      ]
+    }
+  }
+  // `__proto__` is injected as a real JSON key below: a JS object literal would
+  // set the prototype instead of an own property, so it would never reach the
+  // schema. JSON.parse (in the playground's setSchema) does create an own
+  // "__proto__" property, which is what F5 must guard against.
+}).replace(
+  '"formaction":"https://evil.example"',
+  '"formaction":"https://evil.example","__proto__":{"polluted":"yes"}'
+)
+
+Feature('x-buttons')
+
+BeforeSuite(({ I }) => {
+  I.amOnPage(`playground.html?theme=${theme}&iconLib=fontawesome5`)
+  I.selectOption('#examples', pathToSchema)
+  I._waitForElement('.jedi-ready')
+})
+
+Scenario('@feature @x-buttons renders buttons with label, hook class and custom attributes', ({ I }) => {
+  // Hook class present, no theme styling class
+  I._waitForElement('[data-path="#/city"] button.jedi-x-button')
+  I.seeElement('[data-path="#/city"] button.jedi-x-button[type="button"]')
+  I.dontSeeElement('[data-path="#/city"] button.jedi-btn')
+
+  // Custom attributes from the allowlist are applied
+  I.seeElement('[data-path="#/city"] button.jedi-x-button.my-custom-button')
+  I.seeElement('[data-path="#/city"] button.jedi-x-button[data-analytics="detect-city"]')
+
+  // Sanitized HTML label keeps the icon element
+  I.seeElement('[data-path="#/city"] button.jedi-x-button .jedi-x-button-label i.fas.fa-location-dot')
+
+  // Multiple buttons on one editor
+  I.seeElement('[data-path="#/comment"] button.jedi-x-button')
+
+  // Buttons on a container (object) editor
+  I.seeElement('[data-path="#/address"] button.jedi-x-button')
+})
+
+Scenario('@feature @x-buttons emit a namespaced event with { jedison, editor, path }', async ({ I }) => {
+  I.executeScript(() => {
+    window.__xbPayload = null
+    window.__xbCallCount = 0
+    window.editor.on('jedison:detectCity', (payload) => {
+      window.__xbCallCount += 1
+      window.__xbPayload = {
+        path: payload.path,
+        hasJedison: !!payload.jedison,
+        hasEditor: !!payload.editor,
+        editorInstancePath: payload.editor && payload.editor.instance && payload.editor.instance.path
+      }
+    })
+  })
+
+  I._click('[data-path="#/city"] button.jedi-x-button')
+
+  const result = await I.executeScript(() => ({ payload: window.__xbPayload, callCount: window.__xbCallCount }))
+
+  I.assertTrue(!!result.payload, 'jedison:detectCity should have fired')
+  // A single click fires the handler exactly once (no double-fire).
+  I.assertEqual(result.callCount, 1)
+  I.assertEqual(result.payload.path, '#/city')
+  I.assertTrue(result.payload.hasJedison)
+  I.assertTrue(result.payload.hasEditor)
+  I.assertEqual(result.payload.editorInstancePath, '#/city')
+})
+
+Scenario('@feature @x-buttons off(name, cb) removes only the given callback', async ({ I }) => {
+  const result = await I.executeScript(() => {
+    const calls = { a: 0, b: 0 }
+    const cbA = () => { calls.a += 1 }
+    const cbB = () => { calls.b += 1 }
+    window.editor.on('jedison:offTest', cbA)
+    window.editor.on('jedison:offTest', cbB)
+    window.editor.off('jedison:offTest', cbA)
+    window.editor.emit('jedison:offTest', {})
+    window.editor.off('jedison:offTest')
+    return calls
+  })
+
+  I.assertEqual(result.a, 0, 'the removed callback must not fire')
+  I.assertEqual(result.b, 1, 'the remaining callback must still fire')
+})
+
+Scenario('@feature @x-buttons button data never leaks into getValue()', async ({ I }) => {
+  const value = await I.executeScript(() => JSON.stringify(window.editor.getValue()))
+  const leaks = ['detectCity', 'x-buttons', '"event"', '"label"', 'my-custom-button']
+    .some((needle) => value.indexOf(needle) !== -1)
+  I.assertFalse(leaks, `getValue() must not contain button config, got: ${value}`)
+})
+
+Scenario('@feature @x-buttons follow the editor disabled state', ({ I }) => {
+  I._click('#disable-editor')
+  I._waitForElement('[data-path="#/city"] button.jedi-x-button[disabled]')
+  I._click('#enable-editor')
+})
+
+Scenario('@feature @x-buttons filter attributes and sanitize labels against an untrusted schema', async ({ I }) => {
+  I.executeScript((schema) => {
+    window.__xssRan = false
+    window.__onclickRan = false
+    document.querySelector('#schema').value = schema
+  }, maliciousSchema)
+  I._click('#set-schema')
+
+  I._waitForElement('#sec-btn')
+
+  // Allowlisted attributes survive (F1)
+  I.seeElement('button#sec-btn.jedi-x-button[data-ok="yes"]')
+
+  // Disallowed attributes are dropped (F1)
+  I.dontSeeElement('#sec-btn[onclick]')
+  I.dontSeeElement('#sec-btn[style]')
+  I.dontSeeElement('#sec-btn[formaction]')
+
+  // Label is sanitized: the <img> may remain but the onerror handler is stripped (F6)
+  I.dontSeeElement('#sec-btn img[onerror]')
+  // The safe icon in the label survives sanitization
+  I.seeElement('#sec-btn .jedi-x-button-label i.fas.fa-check')
+
+  // Clicking must not trigger an inline handler that was dropped
+  I._click('#sec-btn')
+
+  const flags = await I.executeScript(() => ({
+    xssRan: window.__xssRan === true,
+    onclickRan: window.__onclickRan === true,
+    prototypePolluted: ({}).polluted !== undefined
+  }))
+
+  I.assertFalse(flags.xssRan, 'onerror in a label must never execute (F6)')
+  I.assertFalse(flags.onclickRan, 'a dropped onclick attribute must never execute (F1)')
+  I.assertFalse(flags.prototypePolluted, '__proto__ in attributes must not pollute Object.prototype (F5)')
+})


### PR DESCRIPTION
## Summary

Implements `x-buttons` (from the discussion in #62, originating in #18): a schema option that adds action buttons to **any** editor without them becoming part of the data model. `getValue()`, validation and the resulting JSON stay untouched — the button is a pure UI annotation, consistent with the data-vs-presentation separation raised in #18.

```json
{
  "type": "string",
  "title": "City",
  "x-buttons": [
    {
      "label": "Detect city",
      "event": { "name": "detectCity" },
      "attributes": { "class": "my-custom-button", "data-analytics": "detect-city" }
    }
  ]
}
```

```js
instance.on('jedison:detectCity', ({ editor }) => {
  editor.instance.setValue('Stuttgart')
})
```

## Design decisions

- **Dispatch:** buttons **emit** `jedison:<name>` through the existing internal `EventEmitter` (`jedison.on(...)`), consistent with the current `change` / `instance-change` events. The payload `{ jedison, editor, path }` is passed as the single callback argument. This keeps the payload private to code that already holds the instance (no page-wide/`document` exposure).
- **Element:** `<button type="button">` with a single unstyled hook class `jedi-x-button` (no `jedi-btn`, no theme styling — styling is left to the user).
- **Placement:** appended to the end of the editor container, uniform across all editor types incl. custom editors.
- **Event config:** object form `{ "name": "..." }` only (string shorthand can be added later without breaking).

## Security

The schema is treated as trusted, developer-authored code (same model that already governs `x-inputAttributes` / `x-containerAttributes`). On top of that, `x-buttons` hardens the surface:

- **Attribute allowlist** — a shared `filterAttributes()` helper keeps only `id`, `class`, `title`, `name`, `value`, `disabled`, `always-enabled`, `always-disabled`, `aria-*`, `data-*`; `on*`, `style`, `formaction`, etc. are dropped. Designed to be retrofitted onto the other `x-*attributes` keywords later.
- **Label sanitization** — labels are HTML sanitized through the existing DOMPurify pipeline (`Editor.purifyContent()`), never assigned raw. Icons can be embedded in the label (`<i class="...">` survives sanitization).
- **Prototype pollution** — `__proto__` in the attribute bag is dropped; covered by a regression test.
- The `always-enabled` escape hatch remains available to trusted schemas by design; documented as part of the trust boundary.

## Tests

New e2e suite `tests/e2e/tests/features/x-buttons_test.cjs`:
- renders with label, hook class and custom attributes; no theme class
- emits the namespaced event once per click with `{ jedison, editor, path }`
- `off(name, cb)` removes only the given callback
- button data never leaks into `getValue()`
- buttons follow the editor disabled/read-only state
- XSS: inert-markup label sanitized, `on*`/`style`/`formaction` dropped, `__proto__` does not pollute `Object.prototype`

Unit suite (910) green; e2e green across barebones + bootstrap3/4/5.

## Notes

- Build artifacts (`dist/`, `docs/`) are intentionally left out of this PR — source, playground and tests only.
- Docs PR follows in [jedison-docs](https://github.com/germanbisurgi/jedison-docs).

Closes #62
Closes #18
